### PR TITLE
Fix typeof(composite) causing compiler errors with DMD head.

### DIFF
--- a/source/tested.d
+++ b/source/tested.d
@@ -233,7 +233,7 @@ private class TestRunner {
 	{
 		bool ret = true;
 
-		static if (composite.stringof.startsWith("module ") || isAggregateType!(typeof(composite))) {
+		static if (composite.stringof.startsWith("module ") || (is(typeof(composite)) && isAggregateType!(typeof(composite)))) {
 			foreach (test; __traits(getUnitTests, composite)) {
 				if (!runUnitTest!test())
 					ret = false;


### PR DESCRIPTION
With DMD head, typeof(module) is no longer valid (http://d.puremagic.com/issues/show_bug.cgi?id=9081). This causes isAggregateType to fail with a module, so this pull request just adds a check beforehand to ensure typeof(composite) is valid. It in theory shouldn't affect anything because the change was for modules and there's already a check immediately before to see if composite is a module.
