### PR TITLE
Fixed checking typeof package or module causing isPackage / isModule to be false with DMD head.

### DIFF
--- a/source/tested.d
+++ b/source/tested.d
@@ -395,7 +395,7 @@ private template isModule(DECL...)
 	if (DECL.length == 1)
 {
 	static if (is(DECL[0])) enum isModule = false;
-	else static if (!is(typeof(DECL[0]) == void)) enum isModule = false;
+	else static if (is(typeof(DECL[0])) && !is(typeof(DECL[0]) == void)) enum isModule = false;
 	else static if (!is(typeof(DECL[0].stringof))) enum isModule = false;
 	else static if (is(FunctionTypeOf!(DECL[0]))) enum isModule = false;
 	else enum isModule = DECL[0].stringof.startsWith("module ");
@@ -405,7 +405,7 @@ private template isPackage(DECL...)
 	if (DECL.length == 1)
 {
 	static if (is(DECL[0])) enum isPackage = false;
-	else static if (!is(typeof(DECL[0]) == void)) enum isPackage = false;
+	else static if (is(typeof(DECL[0])) && !is(typeof(DECL[0]) == void)) enum isPackage = false;
 	else static if (!is(typeof(DECL[0].stringof))) enum isPackage = false;
 	else static if (is(FunctionTypeOf!(DECL[0]))) enum isPackage = false;
 	else enum isPackage = DECL[0].stringof.startsWith("package ");


### PR DESCRIPTION
!is(typeof(DECL[0]) == void) is true with DMD head because modules and packages have no type, so isModule and isPackage is always false.
