### PR TITLE
Ensure end of recursive search for unittests.

### DIFF
--- a/example/source/app.d
+++ b/example/source/app.d
@@ -64,3 +64,15 @@ unittest {
 		assert(ints.length < 900, "Too many items");
 	}
 }
+
+struct Recursion{
+    alias Self = Recursion;
+    struct Child{
+        alias Parent = Recursion;
+    }
+
+    @name("recursion must be terminated")
+    unittest{
+        assert(true);
+    }
+}


### PR DESCRIPTION
This fixes infinite recursion in runUnitTestsImpl in case of
a member type being referenced from its submember. The simplest
example is:

    struct Struct{
        alias Self = Struct;
    }

The fix keeps track of all mangled names already visited, so
as to avoid visiting more than once.