### PR TITLE
Compilation error fix – import amendment

### DIFF
--- a/source/tested.d
+++ b/source/tested.d
@@ -11,7 +11,7 @@ import core.sync.mutex;
 import core.memory;
 import core.time;
 import core.thread;
-import std.datetime : StopWatch;
+import std.datetime.stopwatch : StopWatch;
 import std.string : startsWith;
 import std.traits;
 import std.typetuple : TypeTuple;


### PR DESCRIPTION
There has been a change in Phobos some time ago (long enough for the entire deprecation period to pass) that broke the compilation of tested – some classes in `std.datetime` have been moved to subpackages.

I know that this project has not been updated for a few years alredy, but **I would be greatful to its maintainers to accept this one-import-changing PR and release the new tag**. A number of projects on code.dlang.org depend on this libarary and those currently do not build.

Thank you in advance! :)

Fixes #10